### PR TITLE
Update build.json: reorder files

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,5 +1,5 @@
 [
-  "src/Parser.js",
+  "src/boot.js",
   "src/HTMLImports.js",
-  "src/boot.js"
+  "src/Parser.js"
 ]


### PR DESCRIPTION
With the existing (reversed) order I am seeing this error when loading the html-imports.min.js file:
`Uncaught ReferenceError: HTMLImports is not defined`.
