### PR TITLE
XHR edit to support IE9

### DIFF
--- a/src/HTMLImports.js
+++ b/src/HTMLImports.js
@@ -423,7 +423,7 @@ xhr = xhr || {
     request.addEventListener('readystatechange', function(e) {
       if (request.readyState === 4) {
         next.call(nextContext, !xhr.ok(request) && request,
-          request.response, url);
+          request.response || request.responseText, url);
       }
     });
     request.send();


### PR DESCRIPTION
xhr in IE9 only has req.responseText, and not req.response
