### PR TITLE
build: add scope.js and path.js to build.json

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,4 +1,6 @@
 [
+  "src/scope.js",
+  "src/path.js",
   "src/HTMLImports.js",
   "src/Parser.js",
   "src/boot.js"


### PR DESCRIPTION
This allows HTMLImports to work properly when building polymer-dev with grunt.
