### PR TITLE
Fixes for IE

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,4 +1,5 @@
 [
+  "../MutationObservers/build.json",
   "src/scope.js",
   "src/Loader.js",
   "src/Parser.js",

--- a/conf/karma.conf.js
+++ b/conf/karma.conf.js
@@ -13,7 +13,9 @@ module.exports = function(karma) {
       'HTMLImports/html-imports.js',
       {pattern: 'tools/**/*.js', included: false},
       {pattern: 'HTMLImports/src/*', included: false},
-      {pattern: 'HTMLImports/test/**/*', included: false}
+      {pattern: 'HTMLImports/test/**/*', included: false},
+      {pattern: 'MutationObservers/*.js', included: false},
+      {pattern: 'WeakMap/*.js', included: false}
     ],
   }));
 };

--- a/html-imports.js
+++ b/html-imports.js
@@ -9,6 +9,7 @@
 var thisFile = 'html-imports.js';
 var scopeName = 'HTMLImports';
 var modules = [
+  '../MutationObservers/mutation-observers.js',
   'src/scope.js',
   'src/Loader.js',
   'src/Parser.js',

--- a/src/HTMLImports.js
+++ b/src/HTMLImports.js
@@ -164,12 +164,22 @@ var currentScriptDescriptor = {
   get: function() {
     return HTMLImports.currentScript || document.currentScript;
   },
-  writeable: true,
   configurable: true
-}
+};
 
 Object.defineProperty(document, '_currentScript', currentScriptDescriptor);
 Object.defineProperty(mainDoc, '_currentScript', currentScriptDescriptor);
+
+// Polyfill document.baseURI for browsers without it.
+// ShadowDOM Polyfill wrapper should handle this automatically.
+if (!document.baseURI) {
+  Object.defineProperty(document, 'baseURI', {
+    get: function() {
+      return window.location.href;
+    },
+    configurable: true
+  });
+}
 
 // TODO(sorvell): multiple calls will install multiple event listeners
 // which may not be desireable; calls should resolve in the correct order,

--- a/src/Observer.js
+++ b/src/Observer.js
@@ -12,7 +12,8 @@ var importSelector = 'link[rel=' + IMPORT_LINK_TYPE + ']';
 var matches = HTMLElement.prototype.matches || 
     HTMLElement.prototype.matchesSelector || 
     HTMLElement.prototype.webkitMatchesSelector ||
-    HTMLElement.prototype.mozMatchesSelector;
+    HTMLElement.prototype.mozMatchesSelector ||
+    HTMLElement.prototype.msMatchesSelector;
 
 var importer = scope.importer;
 
@@ -22,7 +23,7 @@ function handler(mutations) {
       addedNodes(m.addedNodes);
     }
   }
-};
+}
 
 function addedNodes(nodes) {
   for (var i=0, l=nodes.length, n; (i<l) && (n=nodes[i]); i++) {


### PR DESCRIPTION
add MutationObserver polyfill to loader

Add msMatchesSelector to matches impl check

Fix propertyDescriptor for _currentScript

Polyfill document.baseURI for IE

Remove writable, IE doesn't like it

Only need to define baseURI on real document, don't need to keep the prop descriptor around

Add heuristic to fake load event for IE

Spec says that "load" must always be fired on style element, but IE fails to do so if its resources are either fully
text, or the @imports have already been processed asynchornously.

http://www.whatwg.org/specs/web-apps/current-work/multipage/semantics.html#the-style-element

add MutationObserver and WeakMap to karma serve list
