### PR TITLE
Support importing from Data URIs

### DIFF
--- a/src/Loader.js
+++ b/src/Loader.js
@@ -76,23 +76,38 @@
     },
     fetch: function(url, elt) {
       flags.load && console.log('fetch', url, elt);
-      var receiveXhr = function(err, resource) {
-        this.receive(url, elt, err, resource);
-      }.bind(this);
-      xhr.load(url, receiveXhr);
-      // TODO(sorvell): blocked on
-      // https://code.google.com/p/chromium/issues/detail?id=257221
-      // xhr'ing for a document makes scripts in imports runnable; otherwise
-      // they are not; however, it requires that we have doctype=html in
-      // the import which is unacceptable. This is only needed on Chrome
-      // to avoid the bug above.
-      /*
-      if (isDocumentLink(elt)) {
-        xhr.loadDocument(url, receiveXhr);
+      if (url.match(/^data:/)) {
+        // Handle Data URI Scheme
+        var pieces = url.split(',');
+        var header = pieces[0];
+        var body = pieces[1];
+        if(header.indexOf(';base64') > -1) {
+          body = atob(body);
+        } else {
+          body = decodeURIComponent(body);
+        }
+        setTimeout(function() {
+            this.receive(url, elt, null, body);
+        }.bind(this), 0);
       } else {
+        var receiveXhr = function(err, resource) {
+          this.receive(url, elt, err, resource);
+        }.bind(this);
         xhr.load(url, receiveXhr);
+        // TODO(sorvell): blocked on)
+        // https://code.google.com/p/chromium/issues/detail?id=257221
+        // xhr'ing for a document makes scripts in imports runnable; otherwise
+        // they are not; however, it requires that we have doctype=html in
+        // the import which is unacceptable. This is only needed on Chrome
+        // to avoid the bug above.
+        /*
+        if (isDocumentLink(elt)) {
+          xhr.loadDocument(url, receiveXhr);
+        } else {
+          xhr.load(url, receiveXhr);
+        }
+        */
       }
-      */
     },
     receive: function(url, elt, err, resource) {
       this.cache[url] = resource;

--- a/test/html/HTMLImports.html
+++ b/test/html/HTMLImports.html
@@ -6,6 +6,13 @@
     <script src="../../../tools/test/chai/chai.js"></script>
     <script src="../../html-imports.js"></script>
     <link rel="import" href="imports/import-1.html">
+
+    <!-- the data URI is an html file containing only one import that itself
+         is a data URI of an HTML file containing only a comment. -->
+    <link rel="import" href="data:text/html;charset=utf-8,%3Clink%20rel%3D%22import%22%20href%3D%22data%3Atext%2Fhtml%3Bcharset%3Dutf-8%2C%253C%2521--%2520empty%2520import%2520--%253E%22%3E">
+    <!-- same content as above, but using base64 encoding -->
+    <link rel="import" href="data:text/plain;charset=utf-8;base64,PGxpbmsgcmVsPSJpbXBvcnQiIGhyZWY9ImRhdGE6dGV4dC9wbGFpbjtjaGFyc2V0PXV0Zi04O2Jhc2U2NCxQQ0V0TFNCcWRYTjBJR0VnWTI5dGJXVnVkQ0F0TFQ0PSIgLz4=">
+
   </head>
   <body>
     <script>
@@ -15,10 +22,10 @@
       addEventListener('HTMLImportsLoaded', function() {
         clearTimeout(timeout);
         if (!HTMLImports.useNative) {
-          chai.assert.equal(5, Object.keys(HTMLImports.importLoader.cache).length,
-            'must cache exactly four resources');
-          chai.assert.equal(5, Object.keys(HTMLImports.importer.documents).length,
-            'must cache exactly four documents');
+          chai.assert.equal(9, Object.keys(HTMLImports.importLoader.cache).length,
+            'must cache exactly nine resources');
+          chai.assert.equal(9, Object.keys(HTMLImports.importer.documents).length,
+            'must cache exactly nine documents');
 
           Object.keys(HTMLImports.importer.documents).forEach(function(key) {
             var doc = HTMLImports.importer.documents[key];


### PR DESCRIPTION
This patch adds support for importing content encoded in Data URIs. I've also added tests for utf-8 and base64-encoded URIs. There may be encoding issues with this implementation, but I'm not much of an expert. It works for the cases I've tried (omitting encoding, iso-8859-1, utf-8, and base64) so it may be "good enough" for a polyfill.  
