### PR TITLE
Redirected imports resolve paths relative to resource's redirected location instead of requested location

### DIFF
--- a/src/Loader.js
+++ b/src/Loader.js
@@ -112,7 +112,7 @@
     receive: function(url, elt, err, resource, redirectedUrl) {
       this.cache[url] = resource;
       var $p = this.pending[url];
-      if ( redirectedUrl ) {
+      if ( redirectedUrl && redirectedUrl !== url ) {
         this.cache[redirectedUrl] = resource;
         $p = $p.concat(this.pending[redirectedUrl]);
       }
@@ -125,7 +125,7 @@
         this.tail();
       }
       this.pending[url] = null;
-      if ( redirectedUrl ) {
+      if ( redirectedUrl && redirectedUrl !== url ) {
         this.pending[redirectedUrl] = null;
       }
     },


### PR DESCRIPTION
Fixes Polymer/HTMLImports/issues/61.

When the polyfill receives the contents of an import, it checks for a `Location` header on the response. If present, it takes this as the actual location of the resource. This may differ from the requested location if the server redirected the request.

Example: a page imports a.html, but the server returns a 301 or 302 response and points to b.html instead. The browser now asks for b.html. The server returns this file with `Location` set to b.html. The polyfill then takes b.html as the file's actual location, and resolves any subsequent imports or other resources with respect to that location.

In cross-origin scenarios, the server should also set `Access-Control-Expose-Headers: Location` so that the polyfill will be allowed to inspect the `Location` header.

(Note: I was unable to run the unit tests for HTMLImports; even before making any changes, `grunt test` failed with an error that appears to be related to the Karma configuration file. I've set things up according to the instructions at [here](http://www.polymer-project.org/resources/tooling-strategy.html#git) and [here](https://github.com/Polymer/platform/blob/master/CONTRIBUTING.md) for setting up my dev environment, but don't see anything about configuring Karma. Is there a step missing from the instructions?)
