### PR TITLE
Correct documentation typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-See https://github.com/Polymer/polymer/blob/master/CONTRIBUTING.md
+See https://github.com/Polymer/polymer.github.io/blob/master/CONTRIBUTORS.txt

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The polyfill loads linked stylesheets, external scripts, and nested HTML imports
 
 #### The WebComponentsReady event
 
-Under native imports, `<script>` tags in the main document block the loading of imports. This is to insure the imports have loaded and any registered elements in them have been upgrade. This native behavior is difficult to polyfill so we {{site.project_title}} doesn't try. Instead the `WebComponentsReady` event is a stand in for this behavior:
+Under native imports, `<script>` tags in the main document block the loading of imports. This is to ensure the imports have loaded and any registered elements in them have been upgraded. This native behavior is difficult to polyfill so the [HTML Imports polyfill](https://github.com/Polymer/HTMLImports) doesn't try. Instead the `WebComponentsReady` event is a stand in for this behavior:
 
     <script>
       window.addEventListener('WebComponentsReady', function(e) {


### PR DESCRIPTION
This corrects a few typos in [the section](http://www.polymer-project.org/platform/html-imports.html#the-webcomponentsready-event) documenting the `WebComponentsReady` event.
