### PR TITLE
fix link stylesheet not fire load event in  Android Browser lt 4.4

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -148,9 +148,13 @@ var importParser = {
       self.markParsingComplete(elt);
       self.parseNext();
     };
-    elt.addEventListener('load', done);
-    elt.addEventListener('error', done);
-
+    // NOTE:Android Browser lt 4.4 does not fire load event,fire directly is a good solution
+     if(elt.rel == "stylesheet"){
+    	done();
+    }else{
+    	elt.addEventListener('load', done);
+    	elt.addEventListener('error', done);	
+    }
     // NOTE: IE does not fire "load" event for styles that have already loaded
     // This is in violation of the spec, so we try our hardest to work around it
     if (isIe && elt.localName === 'style') {


### PR DESCRIPTION
Android Browser lt 4.4 does not fire load event,fire directly is a good solution
