### PR TITLE
Always use uri encoded utf-8

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -257,15 +257,7 @@ function nodeIsImport(elt) {
 
 function generateScriptDataUrl(script) {
   var scriptContent = generateScriptContent(script);
-  var b64 = 'data:text/javascript';
-  // base64 may be smaller, but does not handle unicode characters
-  // attempt base64 first, fall back to escaped text
-  try {
-    b64 += (';base64,' + btoa(scriptContent));
-  } catch(e) {
-    b64 += (';charset=utf-8,' + encodeURIComponent(scriptContent));
-  }
-  return b64;
+  return 'data:text/javascript;charset=utf-8,' + encodeURIComponent(scriptContent);
 }
 
 function generateScriptContent(script) {

--- a/test/html/encoding.html
+++ b/test/html/encoding.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title></title>
+  <script src="../../../tools/test/htmltest.js"></script>
+  <script src="../../../tools/test/chai/chai.js"></script>
+  <script src="../../html-imports.js"></script>
+  <link rel="import" href="imports/encoding-import.html">
+</head>
+<body>
+  <span></span>
+  <script>
+    function test() {
+      run();
+      var span = document.querySelector('span');
+      chai.assert.equal(span.textContent, 'Róbert Viðar Bjarnason');
+      done();
+    }
+
+    if (HTMLImports.ready) {
+      test();
+    } else {
+      addEventListener('HTMLImportsLoaded', test);
+    }
+  </script>
+</body>
+</html>

--- a/test/html/imports/encoding-import.html
+++ b/test/html/imports/encoding-import.html
@@ -1,0 +1,6 @@
+<script>
+  function run() {
+    var span = document.querySelector('span');
+    span.textContent = 'Róbert Viðar Bjarnason';
+  };
+</script>

--- a/test/js/tests.js
+++ b/test/js/tests.js
@@ -18,4 +18,5 @@ htmlSuite('HTMLImports', function() {
   // TODO(sjmiles): feature not implemented currently
   //htmlTest('html/dynamic-elements.html');
   htmlTest('html/csp.html');
+  htmlTest('html/encoding.html');
 });


### PR DESCRIPTION
Firefox and IE seem to base64 encode some extended ascii characters just fine, but decode breaks them.
Fixes Polymer/polymer#717
